### PR TITLE
feat: add dark mode theme toggle

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src/AppWorking.backup.tsx']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/components/JsonTreeView.tsx
+++ b/src/components/JsonTreeView.tsx
@@ -13,6 +13,7 @@ interface JsonTreeViewProps {
   onPathSelect: (path: string[]) => void;
   searchTerm?: string;
   viewMode?: 'tree' | 'compact' | 'raw';
+  theme?: 'light' | 'dark';
 }
 
 interface TreeNodeProps {
@@ -24,6 +25,7 @@ interface TreeNodeProps {
   isLast?: boolean;
   parentExpanded?: boolean;
   selectedPath?: string[];
+  theme: 'light' | 'dark';
 }
 
 const TreeNode: React.FC<TreeNodeProps> = ({
@@ -33,12 +35,13 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   onPathSelect,
   searchTerm,
   isLast = false,
-  selectedPath = []
+  selectedPath = [],
+  theme
 }) => {
   const [isExpanded, setIsExpanded] = useState(true);
   const [copiedValue, setCopiedValue] = useState(false);
 
-  const handleCopyValue = async (value: any) => {
+  const handleCopyValue = async (value: JsonData) => {
     try {
       await navigator.clipboard.writeText(
         typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)
@@ -229,7 +232,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
         {path.length > 0 && (
           <>
             <span
-              className="fw-bold text-dark me-2 hover-text-primary"
+              className={`fw-bold me-2 hover-text-primary ${theme === 'dark' ? 'text-light' : 'text-dark'}`}
               onClick={() => onPathSelect(path)}
               style={{ cursor: 'pointer' }}
             >
@@ -247,9 +250,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({
         {!isExpandable && (
           <button
             onClick={() => handleCopyValue(data)}
-            className="btn btn-sm btn-outline-secondary ms-2 py-0 px-1"
+            className={`btn btn-sm ms-2 py-0 px-1 ${theme === 'dark' ? 'btn-outline-light' : 'btn-outline-secondary'}`}
             style={{ fontSize: '0.7rem', opacity: copiedValue ? 1 : 0.3 }}
-            onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
             onMouseLeave={(e) => !copiedValue && (e.currentTarget.style.opacity = '0.3')}
           >
             {copiedValue ? '✓' : '📋'}
@@ -270,6 +273,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 searchTerm={searchTerm}
                 isLast={index === data.length - 1}
                 selectedPath={selectedPath}
+                theme={theme}
               />
             ))
           ) : (
@@ -283,6 +287,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 searchTerm={searchTerm}
                 isLast={index === arr.length - 1}
                 selectedPath={selectedPath}
+                theme={theme}
               />
             ))
           )}
@@ -296,7 +301,8 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
   data,
   onPathSelect,
   searchTerm = '',
-  viewMode = 'tree'
+  viewMode = 'tree',
+  theme = 'light'
 }) => {
   const [selectedPath, setSelectedPath] = useState<string[]>([]);
 
@@ -346,7 +352,7 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
     return (
       <div>
         {breadcrumb}
-        <pre className="bg-light p-3 rounded">
+        <pre className={`p-3 rounded ${theme === 'dark' ? 'bg-dark text-light' : 'bg-light'}`}>
           <code>{JSON.stringify(data, null, 2)}</code>
         </pre>
       </div>
@@ -358,7 +364,7 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
     return (
       <div>
         {breadcrumb}
-        <pre className="bg-light p-3 rounded">
+        <pre className={`p-3 rounded ${theme === 'dark' ? 'bg-dark text-light' : 'bg-light'}`}>
           <code>{JSON.stringify(data)}</code>
         </pre>
       </div>
@@ -381,6 +387,7 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
           onPathSelect={handlePathSelect}
           searchTerm={searchTerm}
           selectedPath={selectedPath}
+          theme={theme}
         />
       </div>
     </div>

--- a/src/components/LanguageExamples.tsx
+++ b/src/components/LanguageExamples.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 interface LanguageExamplesProps {
   path: string[];
+  theme?: 'light' | 'dark';
 }
 
 interface LanguageConfig {
@@ -11,7 +12,7 @@ interface LanguageConfig {
   getExample: (path: string[]) => string;
 }
 
-const LanguageExamples = ({ path }: LanguageExamplesProps) => {
+const LanguageExamples = ({ path, theme = 'light' }: LanguageExamplesProps) => {
   const [showSettings, setShowSettings] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
 
@@ -206,7 +207,7 @@ const LanguageExamples = ({ path }: LanguageExamplesProps) => {
 
   return (
     <div className="d-flex flex-column h-100">
-      <div className="card-header bg-white">
+      <div className={`card-header ${theme === 'dark' ? 'bg-dark' : 'bg-white'}`}>
         <div className="d-flex justify-content-between align-items-center">
           <h6 className="mb-0 fw-bold">
             <i className="bi bi-code-slash me-2 text-primary"></i>
@@ -231,7 +232,7 @@ const LanguageExamples = ({ path }: LanguageExamplesProps) => {
             onClick={() => setShowSettings(false)}
           />
           <div className="position-absolute top-0 end-0 mt-5 me-3" style={{ zIndex: 1050 }}>
-            <div className="card shadow-lg" style={{ width: '250px' }}>
+            <div className={`card shadow-lg ${theme === 'dark' ? 'text-bg-dark' : ''}`} style={{ width: '250px' }}>
               <div className="card-body">
                 <h6 className="card-title mb-3">Select Languages</h6>
                 <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
@@ -268,7 +269,10 @@ const LanguageExamples = ({ path }: LanguageExamplesProps) => {
             {enabledLanguages.map(lang => {
               const example = lang.getExample(path);
               return (
-                <div key={lang.id} className="border rounded p-2 bg-light">
+                <div
+                  key={lang.id}
+                  className={`border rounded p-2 ${theme === 'dark' ? 'bg-dark border-secondary' : 'bg-light'}`}
+                >
                   <div className="d-flex justify-content-between align-items-center mb-1">
                     <span className="fw-semibold small">{lang.name}</span>
                     <button
@@ -293,7 +297,7 @@ const LanguageExamples = ({ path }: LanguageExamplesProps) => {
                       )}
                     </button>
                   </div>
-                  <div className="bg-white p-1 rounded border">
+                  <div className={`${theme === 'dark' ? 'bg-dark border-secondary' : 'bg-white'} p-1 rounded border`}>
                     <code className="text-break" style={{ fontSize: '11px' }}>
                       {example}
                     </code>


### PR DESCRIPTION
## Summary
- add navbar theme toggle storing user preference
- apply Bootstrap dark variants across layout and components
- ignore backup file in eslint config
- initialize theme from system color scheme and track changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7fa9ea5e88333a063c8b6778c84c7